### PR TITLE
feat(plugin-import): Add fallback file resolver logic

### DIFF
--- a/packages/plugin-import/src/index.ts
+++ b/packages/plugin-import/src/index.ts
@@ -19,9 +19,11 @@ const resolveFile = (filePath: string, dirs: string[]): string | null => {
     // Default to node require.resolve() behaviour
     return require.resolve(filePath, { paths: dirs });
   } catch {
-    // Fall back to manual search; resolve absolute path and check for existence
+    // Fall back to manual search
     // eslint-disable-next-line no-restricted-syntax
     for (const searchDir of dirs) {
+      // TODO: Document that user input to path.resolve could lead to a path
+      // traversal vulnerability. Users should only run this on trusted code.
       const resolvedPath = path.resolve(searchDir, filePath);
 
       if (fs.existsSync(resolvedPath)) {


### PR DESCRIPTION
- `@ekscss/plugin.import`: Fall back to manual file resolution when `require.resolve()` fails
- Tweak warning code + add new warning when unable to resolve an `@import`