### PR TITLE
feat: Move resolving string plugins out from the ekscss pacakge

### DIFF
--- a/packages/cli/index.js
+++ b/packages/cli/index.js
@@ -44,6 +44,10 @@ module.exports = async (src, dest, opts) => {
   let srcFileName;
   let srcFile;
 
+  if (config.plugins) {
+    config.plugins = xcss.resolvePlugins(config.plugins);
+  }
+
   for (const filename of srcFiles) {
     try {
       srcFileName = path.resolve(rootDir, filename);

--- a/packages/ekscss/src/helpers.ts
+++ b/packages/ekscss/src/helpers.ts
@@ -261,11 +261,8 @@ export function resolvePlugins(plugins: (Middleware | string)[]): Middleware[] {
         // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
         return (mod.default || mod) as Middleware;
       } catch (error) {
-        ctx.warnings.push({
-          code: 'plugin-load-error',
-          message: `Failed to load plugin "${plugin}"; ${String(error)}`,
-          file: __filename,
-        });
+        // eslint-disable-next-line no-console
+        console.error(`Failed to load plugin "${plugin}"; ${String(error)}`);
         return noop;
       }
     });

--- a/packages/ekscss/src/index.ts
+++ b/packages/ekscss/src/index.ts
@@ -1,3 +1,9 @@
 export { compile, onAfterBuild, onBeforeBuild } from './compiler';
-export { accessorsProxy, ctx, interpolate, xcss } from './helpers';
+export {
+  accessorsProxy,
+  ctx,
+  interpolate,
+  resolvePlugins,
+  xcss,
+} from './helpers';
 export * from './types';

--- a/packages/ekscss/src/types.ts
+++ b/packages/ekscss/src/types.ts
@@ -74,14 +74,14 @@ export interface XCSSCompileOptions {
   map?: boolean | undefined;
   globals?: Partial<XCSSGlobals> | undefined;
   /**
-   * XCSS plugins or package names of XCSS plugins.
+   * XCSS plugins.
    *
    * XCSS plugins are stylis Middleware which may also use the ekscss compiler
    * API. Any valid stylis middleware is also a valid XCSS plugin.
    *
    * @default []
    */
-  plugins?: Array<Middleware | string> | undefined;
+  plugins?: Middleware[] | undefined;
   /**
    * Root directory path to use when resolving file paths e.g., in `@import`.
    *

--- a/packages/ekscss/test/exports.test.ts
+++ b/packages/ekscss/test/exports.test.ts
@@ -14,6 +14,7 @@ const helperPublicExports = [
   ['accessorsProxy', 'function'],
   ['ctx', 'object'],
   ['interpolate', 'function'],
+  ['resolvePlugins', 'function'],
   ['xcss', 'function'],
 ] as const;
 

--- a/packages/esbuild-plugin-ekscss/src/index.ts
+++ b/packages/esbuild-plugin-ekscss/src/index.ts
@@ -1,7 +1,7 @@
 /* eslint-disable no-restricted-syntax */
 // https://esbuild.github.io/plugins/
 
-import { compile, type XCSSCompileOptions } from 'ekscss';
+import { compile, resolvePlugins, type XCSSCompileOptions } from 'ekscss';
 import type { PartialMessage, Plugin } from 'esbuild';
 import fs from 'fs';
 import JoyCon from 'joycon';
@@ -46,6 +46,10 @@ export const xcss = (config?: string | XCSSConfig): Plugin => ({
         } else {
           configData = config || {};
         }
+      }
+
+      if (configData.plugins) {
+        configData.plugins = resolvePlugins(configData.plugins);
       }
 
       const compiled = compile(code, {

--- a/packages/rollup-plugin-ekscss/src/index.ts
+++ b/packages/rollup-plugin-ekscss/src/index.ts
@@ -1,7 +1,7 @@
 /* eslint-disable no-restricted-syntax */
 
 import { createFilter, type FilterPattern } from '@rollup/pluginutils';
-import { compile, type XCSSCompileOptions } from 'ekscss';
+import { compile, resolvePlugins, type XCSSCompileOptions } from 'ekscss';
 import JoyCon from 'joycon';
 import type { Plugin } from 'rollup';
 
@@ -67,6 +67,10 @@ export default function rollupPlugin({
         }
       } else {
         configData = config;
+      }
+
+      if (configData.plugins) {
+        configData.plugins = resolvePlugins(configData.plugins);
       }
     },
 

--- a/packages/svelte-ekscss/src/index.ts
+++ b/packages/svelte-ekscss/src/index.ts
@@ -1,6 +1,6 @@
 /* eslint-disable no-console */
 
-import { compile, type XCSSCompileOptions } from 'ekscss';
+import { compile, resolvePlugins, type XCSSCompileOptions } from 'ekscss';
 import JoyCon from 'joycon';
 import * as colors from 'kleur/colors';
 import type {
@@ -51,6 +51,10 @@ export const style = ({ config }: PluginOptions = {}): Preprocessor => {
       }
     } else {
       configData = config;
+    }
+
+    if (configData.plugins) {
+      configData.plugins = resolvePlugins(configData.plugins);
     }
 
     const compiled = compile(content, {


### PR DESCRIPTION
Move plugin resolving out to each runner package. Keeps the core package simpler and is actually more efficient for each runner too because we now first check there are user supplied plugins.